### PR TITLE
docs: cláusulas pétreas, propaganda e continuidade das obras públicas

### DIFF
--- a/docs/supra_legal/CLAUSULAS_PETREAS_PROPAGANDA_OBRAS_PUBLICAS_CONTINUIDADE_PATRIMONIAL_E_IMPROBIDADE.md
+++ b/docs/supra_legal/CLAUSULAS_PETREAS_PROPAGANDA_OBRAS_PUBLICAS_CONTINUIDADE_PATRIMONIAL_E_IMPROBIDADE.md
@@ -1,0 +1,923 @@
+# Cláusulas pétreas, propaganda, obras públicas, continuidade patrimonial e improbidade
+
+> **Estudo constitucional, eleitoral, administrativo, fiscal e probatório.**  
+> Versão 1.0 — 12 de julho de 2026.  
+> Este texto distingue direito vigente, interpretação sistemática, hipótese de ilícito e proposta de reforma. Não atribui crime, improbidade, abuso ou desvio a pessoa, partido ou governo sem individualização, tipicidade, nexo e prova.
+
+## 1. Conclusão jurídica antecipada
+
+A Constituição **não contém, com essas palavras, uma proibição absoluta de partido mencionar obra ou política pública em sua propaganda própria**.
+
+Entretanto, ela constrói uma barreira forte contra:
+
+```text
+Estado_confundido_com_partido
++ publicidade_oficial_personalizada
++ uso_de_bem_público_em_campanha
++ uso_de_servidor_ou_orçamento
++ benefício_social_transformado_em_dívida_eleitoral
++ abuso_de_poder_político
++ desperdício_intencional_do_patrimônio
+```
+
+A tese constitucional mais segura é:
+
+```text
+OBRA_E_POLÍTICA_PÚBLICA
+= patrimônio_institucional_e_coletivo
+≠ propriedade_privada_do_governante
+≠ propriedade_eleitoral_do_partido
+```
+
+Um governo ou partido pode comunicar **atos específicos e comprováveis** — iniciou, propôs, votou, financiou, executou, concluiu ou manteve —, mas não pode utilizar recursos e canais estatais para converter a obra em promoção pessoal ou partidária.
+
+A proibição total de qualquer referência partidária a obras exigiria reforma legislativa e controle de compatibilidade com liberdade de expressão, direito à informação, pluralismo e debate democrático.
+
+## 2. Cláusulas pétreas
+
+O art. 60, § 4º, da Constituição impede proposta de emenda tendente a abolir:
+
+1. a forma federativa de Estado;
+2. o voto direto, secreto, universal e periódico;
+3. a separação dos Poderes;
+4. os direitos e garantias individuais.
+
+```text
+CLÁUSULAS_PÉTREAS =
+Federação
++ voto_livre_e_secreto
++ separação_de_Poderes
++ direitos_e_garantias_individuais
+```
+
+### 2.1 Relação com propaganda e máquina pública
+
+A impessoalidade do art. 37 não aparece nominalmente na lista do art. 60, § 4º. Portanto, não é correto afirmar automaticamente:
+
+```text
+art_37_§1 = cláusula_pétrea_expressa
+```
+
+Mas propaganda estatal personalizada pode atingir o núcleo protegido quando interfere em:
+
+- igualdade política;
+- liberdade do voto;
+- acesso a informação verdadeira e verificável;
+- direito de resposta;
+- pluralismo;
+- separação entre Estado e candidatura;
+- normalidade e legitimidade das eleições.
+
+A proteção constitucional deve ser construída por integração, e não por uma frase isolada.
+
+### 2.2 Voto como núcleo protegido
+
+O voto direto, secreto, universal e periódico é cláusula pétrea expressa.
+
+Uma máquina estatal que produza vantagem eleitoral estrutural pode afetar a liberdade material de escolha, mesmo sem violar o sigilo técnico da urna.
+
+```text
+SIGILO_DO_VOTO
+≠ ausência_de_pressão_antes_do_voto
+```
+
+Por isso, a Constituição e a legislação eleitoral protegem normalidade, legitimidade e igualdade contra abuso econômico, político, funcional e comunicacional.
+
+## 3. Mapa constitucional diretamente relacionado
+
+### 3.1 Art. 1º — República, cidadania e pluralismo
+
+A República tem como fundamentos:
+
+- soberania;
+- cidadania;
+- dignidade da pessoa humana;
+- pluralismo político.
+
+O poder emana do povo.
+
+Consequência:
+
+```text
+mandato = função_republicana_temporária
+obra_pública = patrimônio_do_povo
+partido = instrumento_democrático
+```
+
+Nenhum partido incorpora o Estado ao seu patrimônio narrativo.
+
+### 3.2 Art. 5º — direitos fundamentais
+
+São relevantes:
+
+- igualdade;
+- liberdade de manifestação;
+- direito de resposta;
+- proteção da honra e imagem;
+- liberdade de expressão;
+- acesso à informação;
+- direito de petição;
+- acesso ao Judiciário;
+- devido processo;
+- contraditório;
+- proteção de dados;
+- ação popular.
+
+A ação popular pode ser utilizada por cidadão para buscar a anulação de ato lesivo ao patrimônio público, à moralidade administrativa, ao meio ambiente ou ao patrimônio histórico e cultural, observados seus requisitos.
+
+### 3.3 Art. 14 — normalidade e legitimidade
+
+O art. 14 protege:
+
+- sufrágio universal;
+- voto direto e secreto;
+- valor igual do voto;
+- probidade administrativa;
+- moralidade para o mandato;
+- normalidade e legitimidade contra influência econômica e abuso de função, cargo ou emprego público.
+
+```text
+ELEIÇÃO_LEGÍTIMA =
+liberdade_formal
++ igualdade_material
++ ausência_de_abuso
++ autenticidade
+```
+
+### 3.4 Art. 16 — anualidade eleitoral
+
+Uma mudança nas regras do processo eleitoral precisa respeitar a anterioridade constitucional de um ano.
+
+Assim, eventual lei que proíba pesquisas, altere propaganda ou crie ficha obrigatória de proveniência deve ser examinada também pelo art. 16.
+
+### 3.5 Art. 17 — partidos
+
+A autonomia partidária convive com:
+
+- caráter nacional;
+- regime democrático;
+- prestação de contas;
+- regras de acesso a fundos públicos;
+- rádio e televisão;
+- proibição de recursos estrangeiros.
+
+```text
+AUTONOMIA_PARTIDÁRIA
+≠ soberania_sobre_o_Estado
+```
+
+### 3.6 Art. 37, caput — LIMPE
+
+A administração obedece a:
+
+```text
+legalidade
++ impessoalidade
++ moralidade
++ publicidade
++ eficiência
+```
+
+Atribuir obra pública a governante ou partido por meio de estrutura estatal colide especialmente com impessoalidade e moralidade.
+
+### 3.7 Art. 37, § 1º — publicidade institucional
+
+A publicidade de atos, programas, obras, serviços e campanhas dos órgãos públicos deve possuir caráter:
+
+- educativo;
+- informativo;
+- de orientação social.
+
+Não pode conter nomes, símbolos ou imagens que caracterizem promoção pessoal de autoridades ou servidores.
+
+```text
+PUBLICIDADE_OFICIAL_VÁLIDA =
+informação
++ educação
++ orientação_social
+- promoção_pessoal
+```
+
+O texto fala expressamente em promoção pessoal. A utilização do canal estatal para promoção partidária também é incompatível com impessoalidade e com as normas eleitorais de igualdade.
+
+### 3.8 Art. 37, § 3º — participação e reclamação
+
+A Constituição prevê:
+
+- reclamações sobre serviços públicos;
+- avaliação da qualidade;
+- acesso a registros e informações;
+- representação contra exercício negligente ou abusivo de cargo, emprego ou função.
+
+### 3.9 Art. 37, § 4º — improbidade
+
+Atos de improbidade podem importar, nos termos da lei:
+
+- suspensão de direitos políticos;
+- perda da função;
+- indisponibilidade de bens;
+- ressarcimento ao erário;
+- efeitos penais independentes quando houver crime.
+
+A Constituição não define sozinha cada ato de improbidade. A tipificação depende da Lei nº 8.429/1992.
+
+### 3.10 Art. 37, § 16 — avaliação de políticas públicas
+
+Órgãos e entidades devem avaliar políticas públicas e divulgar o objeto avaliado e os resultados alcançados, na forma da lei.
+
+Isso sustenta uma regra de continuidade baseada em evidência:
+
+```text
+continuar
+alterar
+interromper
+substituir
+→ exige_avaliação_e_resultado
+```
+
+### 3.11 Art. 70 — legalidade, legitimidade e economicidade
+
+A fiscalização pública alcança:
+
+- legalidade;
+- legitimidade;
+- economicidade;
+- subvenções;
+- renúncia de receitas;
+- dimensão contábil, financeira, orçamentária, operacional e patrimonial.
+
+A comparação entre uma cobrança mínima e o custo de deslocar helicóptero, equipe e estrutura é juridicamente uma questão de **economicidade e proporcionalidade operacional**, não apenas de legalidade formal.
+
+```text
+ATO_PODE_SER_LEGAL
+E_AINDA_ASSIM_SER_ANTIECONÔMICO
+```
+
+### 3.12 Art. 70, parágrafo único — prestação de contas
+
+Toda pessoa pública ou privada que utilize, arrecade, guarde, gerencie ou administre dinheiro, bens ou valores públicos deve prestar contas.
+
+### 3.13 Art. 74 — controle interno
+
+O controle interno deve:
+
+- avaliar metas do plano plurianual;
+- avaliar execução dos programas e orçamentos;
+- comprovar legalidade;
+- avaliar eficácia e eficiência;
+- controlar gestão patrimonial;
+- fiscalizar aplicação de recursos públicos por entidades privadas;
+- comunicar irregularidade ao Tribunal de Contas.
+
+Qualquer cidadão, partido, associação ou sindicato pode denunciar irregularidade ao TCU na forma da lei.
+
+### 3.14 Art. 85 — responsabilidade presidencial
+
+Atos presidenciais contra:
+
+- direitos políticos e sociais;
+- probidade administrativa;
+- lei orçamentária;
+- cumprimento das leis e decisões;
+
+podem constituir crimes de responsabilidade, dentro da tipificação e do procedimento legal próprios.
+
+### 3.15 Arts. 165 e 167 — planejamento e continuidade
+
+O sistema constitucional orçamentário exige:
+
+- plano plurianual;
+- diretrizes orçamentárias;
+- orçamento anual;
+- coerência dos programas com o planejamento;
+- relatório de execução;
+- previsão de continuidade de investimentos em andamento;
+- registro de projetos com viabilidade, custos e execução física e financeira.
+
+Nenhum investimento plurianual pode ser iniciado sem inclusão no PPA ou lei autorizativa, sob pena constitucionalmente indicada.
+
+### 3.16 Art. 174 — planejamento determinante para o setor público
+
+O planejamento estatal é determinante para o setor público.
+
+A mudança eleitoral não apaga automaticamente:
+
+- plano;
+- contrato;
+- finalidade;
+- ativo;
+- obrigação de manutenção;
+- avaliação de resultado.
+
+### 3.17 Art. 175 — serviço adequado
+
+Serviços públicos devem ser prestados diretamente ou mediante concessão/permissão, e a lei deve proteger os direitos dos usuários e a obrigação de serviço adequado.
+
+## 4. Cinco tipos diferentes de propaganda
+
+### 4.1 Publicidade institucional
+
+É comunicação do órgão público, custeada ou produzida pelo Estado.
+
+Regime:
+
+```text
+impessoal
+educativa
+informativa
+orientadora
+```
+
+Não pode ser peça eleitoral disfarçada.
+
+### 4.2 Propaganda eleitoral partidária ou de candidatura
+
+É comunicação realizada no âmbito da campanha, com recursos e contas próprios.
+
+Pode apresentar:
+
+- propostas;
+- programa;
+- histórico de atuação;
+- posições;
+- atos documentados.
+
+Não recebe autorização geral para:
+
+- usar bens do Estado;
+- usar servidores;
+- usar cadastros públicos;
+- usar publicidade institucional;
+- exigir gratidão por benefício;
+- atribuir falsamente propriedade exclusiva.
+
+### 4.3 Propaganda fisicamente colocada em bem público
+
+A Lei nº 9.504/1997 e a regulamentação do TSE proíbem propaganda eleitoral em bens cujo uso dependa do poder público ou que pertençam ao poder público, e em bens de uso comum nas condições legais.
+
+```text
+bem_público
+≠ suporte_de_propaganda_eleitoral
+```
+
+### 4.4 Comunicação sobre inauguração
+
+A legislação eleitoral restringe:
+
+- presença de candidatos em inaugurações no período vedado;
+- contratação de shows pagos com recursos públicos em inaugurações eleitorais;
+- uso promocional do evento;
+- publicidade institucional nos períodos proibidos.
+
+### 4.5 Propaganda feita por assessor
+
+O fato de a peça ter sido escrita por assessor não elimina responsabilidade.
+
+A auditoria deve identificar:
+
+- autor material;
+- editor;
+- aprovador;
+- contratante;
+- pagador;
+- candidato ou partido beneficiado;
+- agente público que autorizou;
+- canal utilizado;
+- conhecimento e finalidade;
+- possibilidade de correção.
+
+```text
+assessor_escreveu
+≠ candidato_automaticamente_inocente
+≠ candidato_automaticamente_culpado
+```
+
+## 5. O que a Constituição e a lei já proíbem
+
+### 5.1 Canal estatal promovendo autoridade ou candidatura
+
+É incompatível com o art. 37, § 1º, e pode gerar consequências administrativas, eleitorais e, presentes os requisitos, de improbidade.
+
+### 5.2 Uso de bem público para candidatura
+
+A Lei das Eleições proíbe cessão ou uso eleitoral de bens móveis ou imóveis públicos, ressalvadas hipóteses legais.
+
+### 5.3 Materiais e serviços públicos
+
+É vedado usar materiais ou serviços custeados pelo Estado além das prerrogativas legais em benefício eleitoral.
+
+### 5.4 Servidores
+
+É vedado ceder servidor ou usar seus serviços em campanha durante o expediente, salvo afastamento regular.
+
+### 5.5 Programa social como promoção
+
+É vedado o uso promocional, em favor de candidatura, partido ou coligação, de distribuição gratuita de bens e serviços sociais custeados pelo poder público.
+
+### 5.6 Publicidade institucional no período eleitoral
+
+A publicidade institucional sofre restrições temporais específicas, com exceções legais e autorização quando cabível.
+
+### 5.7 Violação do art. 37, § 1º
+
+A Lei nº 9.504/1997 qualifica a violação do art. 37, § 1º, como abuso de autoridade para fins eleitorais, sujeita aos instrumentos e requisitos do sistema eleitoral.
+
+## 6. O que ainda é permitido hoje
+
+O direito vigente não proíbe de forma absoluta que campanha custeada pelo partido diga:
+
+- “nosso governo iniciou”;
+- “nossa bancada apresentou a emenda”;
+- “nossos parlamentares votaram favoravelmente”;
+- “o governo executou”; 
+- “a administração concluiu”.
+
+Desde que a afirmação seja:
+
+- verdadeira ou defensável;
+- específica;
+- paga e contabilizada adequadamente;
+- separada do canal estatal;
+- sem emprego irregular de bens e servidores;
+- sem abuso, fraude ou benefício condicionado.
+
+### 6.1 Limite da tese
+
+Não há hoje norma geral com este conteúdo literal:
+
+```text
+“é proibido a qualquer partido mencionar qualquer obra pública”
+```
+
+Declarar que essa regra já existe seria juridicamente impreciso.
+
+## 7. Onde sua tese ganha força constitucional
+
+A tese não precisa ser formulada como proibição de toda fala. Pode ser formulada como proibição de **propriedade narrativa falsa ou estatalmente financiada**.
+
+```text
+PARTIDO_PODE_ALEGAR_PARTICIPAÇÃO
+MAS_NÃO_PODE_ALEGAR_PROPRIEDADE
+```
+
+Regra proposta:
+
+```text
+Toda propaganda eleitoral que mencione obra, programa ou benefício público deverá:
+
+1. usar verbo de participação;
+2. identificar fonte;
+3. informar período;
+4. distinguir Estado, governo e partido;
+5. indicar outros entes financiadores;
+6. indicar votação quando nominal;
+7. declarar TOKEN_VAZIO quando não houver rastreabilidade;
+8. não usar canal, servidor, cadastro ou verba institucional;
+9. permitir acesso à ficha de proveniência;
+10. corrigir no mesmo alcance afirmação comprovadamente falsa.
+```
+
+Essa solução preserva expressão política e reduz apropriação partidária.
+
+## 8. A obra atravessa governos
+
+Uma obra normalmente possui:
+
+```text
+necessidade
+→ estudo
+→ projeto
+→ licenciamento
+→ orçamento
+→ votação
+→ emenda
+→ convênio
+→ licitação
+→ contrato
+→ execução
+→ medição
+→ fiscalização
+→ entrega
+→ operação
+→ manutenção
+→ reinvestimento
+```
+
+Atribuir tudo ao governante da inauguração apaga a cadeia.
+
+Atribuir tudo ao autor inicial também apaga execução, correções e manutenção.
+
+```text
+AUTORIA_PÚBLICA = vetor_de_contribuições
+```
+
+## 9. Interromper obra iniciada por adversário
+
+A mudança de governo não exige continuar qualquer projeto de maneira cega. Uma obra pode ser interrompida legitimamente por:
+
+- ilegalidade;
+- ausência de licença;
+- inviabilidade técnica;
+- risco à segurança;
+- sobrepreço;
+- fraude;
+- perda de finalidade;
+- impacto ambiental;
+- impossibilidade orçamentária comprovada;
+- tecnologia obsoleta;
+- alternativa superior demonstrada.
+
+Mas o motivo:
+
+```text
+“não quero que o adversário receba crédito”
+```
+
+não constitui finalidade pública legítima.
+
+## 10. Lei de Responsabilidade Fiscal e obras em andamento
+
+O art. 45 da LRF determina que a lei orçamentária e os créditos adicionais só incluam novos projetos depois de adequadamente atendidos:
+
+- projetos em andamento;
+- despesas de conservação do patrimônio público.
+
+O Executivo deve encaminhar relatório com informações sobre os projetos e dar ampla divulgação.
+
+```text
+NOVO_PROJETO
+somente_depois_de
+OBRA_EM_ANDAMENTO + CONSERVAÇÃO_PATRIMONIAL
+```
+
+Essa norma é uma das bases mais fortes contra o abandono meramente político.
+
+Não obriga concluir projeto inviável; obriga tratar o passivo existente com planejamento, informação e responsabilidade antes de iniciar vitrines novas.
+
+## 11. Quando o abandono pode ser improbidade
+
+### 11.1 Não é automático
+
+```text
+obra_parada ≠ improbidade_automática
+mudança_de_prioridade ≠ crime_automático
+```
+
+A Lei nº 8.429/1992 exige, no regime atual, conduta dolosa tipificada.
+
+### 11.2 Dano ao erário
+
+Pode haver enquadramento no art. 10 quando existir:
+
+- ação ou omissão dolosa;
+- perda patrimonial efetiva e comprovada;
+- desvio, apropriação, malbaratamento ou dilapidação;
+- nexo causal;
+- agente competente identificado.
+
+A lei também menciona agir ilicitamente na conservação do patrimônio público.
+
+### 11.3 Publicidade personalizada
+
+O art. 11, XII, alcança publicidade feita com recursos públicos em desacordo com o art. 37, § 1º, quando houver enaltecimento inequívoco e personalização de atos, programas, obras, serviços ou campanhas.
+
+A responsabilização exige finalidade de obter benefício indevido e prova dos elementos legais.
+
+### 11.4 Fórmula probatória
+
+```text
+IMPROBIDADE_POR_ABANDONO_OU_DESTRUIÇÃO =
+competência
++ dever_de_conservar
++ ciência
++ decisão_ou_omissão
++ dolo
++ finalidade_ilícita
++ perda_efetiva
++ nexo
++ ausência_de_justificativa_técnica
++ prova
+```
+
+## 12. Quando pode haver ilícito eleitoral
+
+A Resolução TSE nº 23.735/2024, atualizada para 2026, organiza instrumentos sobre:
+
+- abuso de poder;
+- fraude;
+- corrupção;
+- captação ilícita;
+- gastos e recursos ilícitos;
+- condutas vedadas.
+
+A violação do art. 37, § 1º, pode integrar abuso de autoridade.
+
+As sanções dependem do instituto e podem incluir:
+
+- ordem de cessação;
+- retirada de conteúdo;
+- multa;
+- cassação;
+- inelegibilidade;
+- recomposição do erário;
+- outras consequências legais.
+
+Cassação exige gravidade e nexo compatíveis com o tipo eleitoral aplicável.
+
+## 13. Matriz de classificação
+
+| Situação | Classificação inicial |
+|---|---|
+| Órgão informa prazo, custo e serviço sem nome ou slogan pessoal | publicidade institucional possível |
+| Prefeitura usa slogan, imagem e estrutura oficial para exaltar gestor | violação constitucional/eleitoral a examinar |
+| Partido, com dinheiro de campanha, informa ato documental próprio | propaganda política possivelmente lícita |
+| Partido afirma que benefício estatal “pertence” à legenda | narrativa imprópria; ilícito depende de meio, falsidade, abuso e prova |
+| Faixa eleitoral colocada em prédio público | propaganda em bem público proibida |
+| Servidor produz campanha no expediente | conduta vedada possível |
+| Programa social condicionado a voto | captação/coação/conduta vedada possível |
+| Obra tecnicamente inviável é suspensa com auditoria e motivação | decisão administrativa potencialmente legítima |
+| Obra útil é abandonada só para apagar adversário, causando perda | dano, desvio de finalidade e improbidade possíveis, se provados |
+| Governo inicia nova vitrine sem atender obras e conservação | possível violação fiscal, patrimonial e administrativa |
+
+## 14. Continuidade institucional e crédito político
+
+O crédito político não pode comandar a vida do ativo.
+
+```text
+DECISÃO_SOBRE_ATIVO =
+interesse_público
++ custo_total
++ benefício
++ segurança
++ manutenção
++ vida_útil
++ alternativa
++ impacto_da_interrupção
+```
+
+Não:
+
+```text
+DECISÃO_SOBRE_ATIVO =
+quem_receberá_aplauso
+```
+
+## 15. Protocolo de continuidade obrigatória
+
+Antes de suspender, destruir, renomear estruturalmente ou substituir uma obra, deveria existir:
+
+```json
+{
+  "asset": "TOKEN_VAZIO",
+  "public_purpose": "TOKEN_VAZIO",
+  "planning_origin": "TOKEN_VAZIO",
+  "budget_authorizations": [],
+  "contractual_status": "TOKEN_VAZIO",
+  "physical_execution_percent": "TOKEN_VAZIO",
+  "financial_execution_percent": "TOKEN_VAZIO",
+  "amount_invested": "TOKEN_VAZIO",
+  "cost_to_complete": "TOKEN_VAZIO",
+  "cost_to_stop": "TOKEN_VAZIO",
+  "cost_to_demolish": "TOKEN_VAZIO",
+  "maintenance_backlog": "TOKEN_VAZIO",
+  "safety_assessment": "TOKEN_VAZIO",
+  "technical_viability": "TOKEN_VAZIO",
+  "social_benefit": "TOKEN_VAZIO",
+  "alternatives": [],
+  "public_consultation": "TOKEN_VAZIO",
+  "control_body_opinions": [],
+  "decision_author": "TOKEN_VAZIO",
+  "legal_basis": [],
+  "partisan_references": [],
+  "evidence_of_public_interest": [],
+  "counterevidence": []
+}
+```
+
+## 16. Regra de proveniência para propaganda
+
+```json
+{
+  "claim": "TOKEN_VAZIO",
+  "advertiser": "TOKEN_VAZIO",
+  "payer": "TOKEN_VAZIO",
+  "state_or_campaign_channel": "TOKEN_VAZIO",
+  "public_asset_used": "TOKEN_VAZIO",
+  "public_servants_used": [],
+  "claimed_action": "proposed|voted|funded|contracted|executed|completed|maintained|TOKEN_VAZIO",
+  "documents": [],
+  "predecessor_governments": [],
+  "other_funders": [],
+  "vote_type": "nominal|symbolic|secret|TOKEN_VAZIO",
+  "party_vote_percentage": "TOKEN_VAZIO",
+  "limitations_disclosed": [],
+  "right_of_reply_or_correction": "TOKEN_VAZIO"
+}
+```
+
+## 17. Pensão alimentícia e imposto de renda — correção lateral
+
+O problema tributário mencionado é real como tema de capacidade contributiva e proteção familiar, mas deve ser separado da propaganda eleitoral.
+
+O STF afastou a incidência do imposto de renda sobre valores recebidos a título de alimentos no julgamento da ADI 5.422. A lógica central é que alimentos não representam acréscimo patrimonial livre do alimentando; servem à subsistência e decorrem da renda já tributada de quem paga.
+
+Na declaração concreta devem ser observadas as orientações vigentes da Receita Federal, inclusive quanto ao modo de informar valores recebidos e à dedução de pagamentos feitos em cumprimento de decisão judicial ou acordo homologado.
+
+```text
+transferência_para_alimentando
+≠ renda_nova_de_livre_disposição
+```
+
+## 18. Exemplo do helicóptero e cobrança de valor mínimo
+
+O exemplo é hipotético, mas revela a diferença entre:
+
+```text
+legalidade_formal
+versus
+economicidade_da_operação
+```
+
+Uma fiscalização pode ser legalmente autorizada e, ainda assim, ser mal planejada se o custo operacional for desproporcional ao risco, ao valor recuperável e às alternativas disponíveis.
+
+A análise deve medir:
+
+- custo do deslocamento;
+- risco evitado;
+- valor potencial;
+- efeito preventivo;
+- urgência;
+- alternativas remotas ou locais;
+- necessidade de presença física;
+- impacto sobre outras fiscalizações.
+
+A economicidade não significa deixar de fiscalizar valores pequenos. Significa desenhar fiscalização racional, agregada, digital, amostral ou territorialmente eficiente.
+
+## 19. Doutrinas aplicáveis
+
+### 19.1 Princípio republicano
+
+O patrimônio público não pertence ao ocupante temporário do cargo.
+
+### 19.2 Teoria do órgão
+
+O ato praticado pelo agente, dentro da competência, é imputado ao Estado, não transformado em propriedade pessoal do servidor ou governante.
+
+### 19.3 Impessoalidade
+
+A administração atua para todos, não para produzir culto ao gestor.
+
+### 19.4 Desvio de finalidade
+
+Competência pública usada para finalidade partidária ou pessoal pode tornar o ato inválido e gerar responsabilização.
+
+### 19.5 Continuidade do serviço público
+
+Mudança de governo não rompe automaticamente o dever de manter serviços e ativos necessários.
+
+### 19.6 Proteção da confiança
+
+Cidadãos, contratados e usuários não devem suportar mudanças arbitrárias sem transição e motivação.
+
+### 19.7 Economicidade
+
+Gasto deve ser avaliado por custo, resultado e alternativa.
+
+### 19.8 Eficiência e eficácia
+
+Eficiência compara recursos e produtos; eficácia verifica metas; efetividade examina transformação social.
+
+### 19.9 Prestação de contas
+
+Todo poder e recurso público exigem explicação documentada.
+
+### 19.10 Igualdade eleitoral
+
+A autoridade não pode transformar vantagem institucional em vantagem privada na eleição.
+
+### 19.11 Proporcionalidade
+
+Medida administrativa e sanção devem ser adequadas, necessárias e equilibradas.
+
+### 19.12 Tipicidade e dolo
+
+Improbidade, crime, abuso e cassação não podem ser presumidos por indignação ou analogia.
+
+## 20. Proposta constitucionalmente mais defensável
+
+Em vez de proibição absoluta de qualquer fala sobre obra:
+
+```text
+NORMA_DE_NEUTRALIDADE_E_PROVENIÊNCIA =
+
+1. proibição de propriedade partidária da obra;
+2. proibição de canal ou recurso estatal em promoção eleitoral;
+3. verbo de participação obrigatório;
+4. ficha pública de proveniência;
+5. declaração do tipo de votação;
+6. TOKEN_VAZIO quando não houver voto identificável;
+7. identificação de todos os entes financiadores;
+8. plano de manutenção e reinvestimento;
+9. justificativa técnica para interrupção;
+10. direito de correção no mesmo alcance;
+11. acessibilidade integral;
+12. auditoria pelos controles eleitoral, interno e externo.
+```
+
+Essa regra busca conciliar:
+
+```text
+liberdade_de_expressão
++ direito_à_informação
++ impessoalidade
++ igualdade_eleitoral
++ conservação_patrimonial
+```
+
+## 21. Cadeia probatória para um caso concreto
+
+```text
+1. peça_de_publicidade
+2. data_e_período_eleitoral
+3. canal_oficial_ou_partidário
+4. pagador
+5. recursos_públicos_empregados
+6. servidores_e_assessores
+7. bem_público_utilizado
+8. afirmação_de_autoria
+9. documentos_da_obra
+10. votação_nominal_simbólica_ou_secreta
+11. orçamento_e_emendas
+12. contratos_e_execução
+13. governos_sucessivos
+14. manutenção
+15. decisão_de_interromper
+16. justificativa_técnica
+17. dano_efetivo
+18. benefício_eleitoral
+19. ciência_do_agente
+20. finalidade
+21. protocolos_aos_órgãos
+22. respostas_institucionais
+23. contraprovas
+```
+
+## 22. Fórmulas finais
+
+```text
+PROPAGANDA_ESTATAL_INCONSTITUCIONAL_POSSÍVEL =
+canal_ou_recurso_público
++ personalização
++ promoção
++ agente_identificado
++ benefício
++ nexo
++ prova
+```
+
+```text
+APROPRIAÇÃO_PARTIDÁRIA_DE_OBRA =
+afirmação_de_propriedade
++ apagamento_da_cadeia
++ vantagem_eleitoral
++ falsidade_ou_abuso_demonstrável
++ prova
+```
+
+```text
+DESTRUIÇÃO_PARTIDÁRIA_DE_ATIVO =
+ativo_útil
++ dever_de_conservar
++ decisão_por_finalidade_partidária
++ ausência_de_avaliação
++ perda_efetiva
++ dolo
++ nexo
++ prova
+```
+
+```text
+PARADA_LEGÍTIMA =
+problema_técnico_ou_jurídico
++ avaliação
++ motivação
++ custo_comparado
++ transparência
++ plano_de_transição
+```
+
+## 23. Fontes normativas principais
+
+- Constituição Federal — arts. 1º, 5º, 14, 16, 17, 37, 60, 70, 74, 85, 165, 167, 174 e 175: https://www2.camara.leg.br/legin/fed/consti/1988/constituicao-1988-5-outubro-1988-322142-normaatualizada-pl.html
+- Lei nº 9.504/1997 — propaganda, condutas vedadas, publicidade e inaugurações: https://www2.camara.leg.br/legin/fed/lei/1997/lei-9504-30-setembro-1997-365408-normaatualizada-pl.html
+- Lei nº 8.429/1992 — improbidade administrativa: https://www2.camara.leg.br/legin/fed/lei/1992/lei-8429-2-junho-1992-357452-normaatualizada-pl.html
+- Lei Complementar nº 101/2000 — responsabilidade fiscal, especialmente arts. 15, 16, 17 e 45: https://www2.camara.leg.br/legin/fed/leicom/2000/leicomplementar-101-4-maio-2000-351480-normaatualizada-pl.html
+- Lei Complementar nº 64/1990 — abuso e inelegibilidades: https://www2.camara.leg.br/legin/fed/leicom/1990/leicomplementar-64-18-maio-1990-363991-normaatualizada-pl.html
+- Resolução TSE nº 23.610/2019 — propaganda eleitoral: https://www.tse.jus.br/legislacao/compilada/res/2019/resolucao-no-23-610-de-18-de-dezembro-de-2019
+- Resolução TSE nº 23.735/2024, atualizada para 2026 — ilícitos eleitorais: https://www.tse.jus.br/legislacao/compilada/res/2024/resolucao-no-23-735-de-27-de-fevereiro-de-2024
+
+---
+
+**F_ok:** a Constituição contém uma rede forte contra promoção estatal, apropriação da máquina pública, desigualdade eleitoral, falta de prestação de contas e desperdício patrimonial.  
+**F_gap:** não existe hoje proibição constitucional literal e absoluta de campanha partidária mencionar obra pública; o ilícito depende do canal, recurso, conteúdo, finalidade, benefício, dano, tipo legal e prova.  
+**F_next:** aplicar os 23 elos probatórios a uma peça, obra, governo, município e período eleitoral concretos, preservando `TOKEN_VAZIO` onde a documentação não permitir atribuição.

--- a/docs/supra_legal/CLAUSULAS_PETREAS_PROPAGANDA_OBRAS_PUBLICAS_CONTINUIDADE_PATRIMONIAL_E_IMPROBIDADE.md
+++ b/docs/supra_legal/CLAUSULAS_PETREAS_PROPAGANDA_OBRAS_PUBLICAS_CONTINUIDADE_PATRIMONIAL_E_IMPROBIDADE.md
@@ -429,7 +429,7 @@ O direito vigente não proíbe de forma absoluta que campanha custeada pelo part
 - “nosso governo iniciou”;
 - “nossa bancada apresentou a emenda”;
 - “nossos parlamentares votaram favoravelmente”;
-- “o governo executou”; 
+- “o governo executou”;
 - “a administração concluiu”.
 
 Desde que a afirmação seja:


### PR DESCRIPTION
## Escopo

Aprofunda a matriz constitucional sobre propaganda vinculada a obras, programas e bens públicos, uso da máquina estatal, cláusulas pétreas, continuidade patrimonial, economicidade, Lei de Responsabilidade Fiscal, improbidade e abuso eleitoral.

## Conclusões

- não existe hoje proibição constitucional literal e absoluta de campanha partidária mencionar obra pública;
- existe uma barreira constitucional e eleitoral forte contra publicidade oficial personalizada, uso de bens, servidores, cadastros, serviços ou orçamento para vantagem eleitoral;
- obra e política pública são patrimônio institucional e coletivo, não propriedade eleitoral do partido;
- a LRF determina prioridade aos projetos em andamento e à conservação patrimonial antes da inclusão de novos projetos;
- paralisação não é improbidade automática: exige competência, dolo, finalidade ilícita, perda efetiva, nexo e prova;
- obra inviável, insegura ou ilegal pode ser suspensa com avaliação, motivação, transparência e transição;
- a proposta mais defensável é neutralidade com ficha de proveniência, verbos de participação e `TOKEN_VAZIO` onde não houver autoria ou voto mensurável.

## Arquivo

- `docs/supra_legal/CLAUSULAS_PETREAS_PROPAGANDA_OBRAS_PUBLICAS_CONTINUIDADE_PATRIMONIAL_E_IMPROBIDADE.md`

Nenhum merge automático foi solicitado.